### PR TITLE
fix loader bug for sass compile

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,8 +38,8 @@ module.exports = {
         use: [
           MiniCssExtractPlugin.loader, // Extract css to separate file
           'css-loader', // translates CSS into CommonJS
+          'postcss-loader', // parse CSS and add vendor prefixes to CSS rules
           'sass-loader', // compiles Sass to CSS, using Node Sass by default
-          "postcss-loader" // parse CSS and add vendor prefixes to CSS rules
         ],
       },
 


### PR DESCRIPTION
Исправление ошибки сборки, при которой автопрефиксер не работал должным образом.
Подробности бага в моем маленьком расследовании: 
https://www.evernote.com/shard/s324/sh/2c6c718c-a27d-45ea-9f0c-be78b7854c0e/d3d1bca49845b3ea2fe76537a34a633e